### PR TITLE
feat: setup FileProvider and temp cache for receipt image uploads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation("io.coil-kt:coil-compose:2.3.0")
+    implementation("androidx.compose.material:material-icons-extended")
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -60,4 +63,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" >
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Permissions & features -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -10,19 +16,29 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AIBudgetApp" >
+        android:theme="@style/Theme.AIBudgetApp">
+
+        <!-- FileProvider for saving camera images -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/receipt_paths" />
+        </provider>
 
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.AIBudgetApp" >
+            android:theme="@style/Theme.AIBudgetApp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application>
 
+    </application>
 </manifest>

--- a/app/src/main/java/com/example/aibudgetapp/ImageUtils.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ImageUtils.kt
@@ -1,0 +1,21 @@
+package com.example.aibudgetapp
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+
+fun createImageUri(context: Context): Uri {
+    // Creates a temp file inside your app cache
+    val imagesDir = File(context.cacheDir, "images").apply { mkdirs() }
+    val imageFile = File.createTempFile("camera_", ".jpg", imagesDir)
+
+    // Return content:// URI to give camera app a safe place to write
+    return FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        imageFile
+    )
+}
+
+

--- a/app/src/main/java/com/example/aibudgetapp/MainActivity.kt
+++ b/app/src/main/java/com/example/aibudgetapp/MainActivity.kt
@@ -7,6 +7,14 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.*
 import com.example.aibudgetapp.ui.screens.login.*
 import com.example.aibudgetapp.ui.screens.screenContainer.ScreenContainer
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+
 
 class MainActivity : ComponentActivity() {
 

--- a/app/src/main/java/com/example/aibudgetapp/ui/components/UploadPhotoButton.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/components/UploadPhotoButton.kt
@@ -1,0 +1,88 @@
+package com.example.aibudgetapp.ui.components
+
+import android.Manifest
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.aibudgetapp.createImageUri
+
+@Composable
+fun UploadPhotoButton(
+    onImagePicked: (Uri) -> Unit
+) {
+    val context = LocalContext.current
+    var showChooser by remember { mutableStateOf(false) }
+    var pendingCameraUri: Uri? by remember { mutableStateOf(null) }
+
+    // Gallery picker (explicit type in lambda)
+    val galleryPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri: Uri? ->
+        uri?.let(onImagePicked)
+    }
+
+    // Camera capture (explicit Boolean)
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { ok: Boolean ->
+        if (ok) pendingCameraUri?.let(onImagePicked)
+    }
+
+    // Camera permission
+    val cameraPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted: Boolean ->
+        if (granted) {
+            pendingCameraUri = createImageUri(context).also { cameraLauncher.launch(it) }
+        }
+    }
+
+    Button(
+        onClick = { showChooser = true },
+        modifier = Modifier
+            .padding(top = 24.dp)
+            .fillMaxWidth(0.8f)
+    ) {
+        Icon(imageVector = Icons.Filled.Camera, contentDescription = "Camera")
+        Spacer(modifier = Modifier.width(8.dp))
+        Text("Upload photo")
+    }
+
+    if (showChooser) {
+        AlertDialog(
+            onDismissRequest = { showChooser = false },
+            title = { Text("Add receipt") },
+            text = { Text("Choose a source") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showChooser = false
+                    galleryPicker.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                }) { Text("Gallery") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showChooser = false
+                    cameraPermission.launch(Manifest.permission.CAMERA)
+                }) { Text("Camera") }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionScreen.kt
@@ -1,25 +1,19 @@
 package com.example.aibudgetapp.ui.screens.transaction
 
+import android.net.Uri                                   // ✅ NEW
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
-
-
+import com.example.aibudgetapp.ui.components.UploadPhotoButton   // ✅ NEW
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-
 fun AddTransactionScreen(
     onAddTransaction: (Int, String) -> Unit,
     AddTransactionError: Boolean
@@ -28,6 +22,9 @@ fun AddTransactionScreen(
     var selected by remember { mutableStateOf(list[0]) }
     var amount by remember { mutableIntStateOf(0) }
     var isExpanded by remember { mutableStateOf(false) }
+
+    // ✅ NEW: hold the chosen image locally (no DB / VM needed yet)
+    var receiptUri by remember { mutableStateOf<Uri?>(null) }
 
     Column(
         verticalArrangement = Arrangement.Top,
@@ -40,27 +37,43 @@ fun AddTransactionScreen(
             text = "Add Transaction",
             style = MaterialTheme.typography.bodyLarge,
         )
+
+        // ✅ NEW: Upload button (shows Camera or Gallery dialog)
+        UploadPhotoButton { uri ->
+            receiptUri = uri
+        }
+
+        // Optional: let the user know something is attached
+        if (receiptUri != null) {
+            Text(
+                text = "Receipt attached",
+                color = Color.Gray,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
         OutlinedTextField(
             value = amount.toString(),
-            onValueChange = {amount = it.toIntOrNull() ?: 0 },
-            label = { Text("Amount")},
+            onValueChange = { amount = it.toIntOrNull() ?: 0 },
+            label = { Text("Amount") },
             modifier = Modifier.fillMaxWidth(),
         )
+
         ExposedDropdownMenuBox(
             expanded = isExpanded,
-            onExpandedChange = {isExpanded = !isExpanded},
+            onExpandedChange = { isExpanded = !isExpanded },
         ) {
             TextField(
                 modifier = Modifier.menuAnchor().fillMaxWidth(),
                 value = selected,
                 onValueChange = {},
                 readOnly = true,
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded)}
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded) }
             )
-            ExposedDropdownMenu(expanded = isExpanded, onDismissRequest = {isExpanded = false}) {
+            ExposedDropdownMenu(expanded = isExpanded, onDismissRequest = { isExpanded = false }) {
                 list.forEachIndexed { index, text ->
                     DropdownMenuItem(
-                        text = {Text(text = text)},
+                        text = { Text(text = text) },
                         onClick = {
                             selected = list[index]
                             isExpanded = false
@@ -70,23 +83,29 @@ fun AddTransactionScreen(
                 }
             }
         }
+
         Text(text = "Currently selected: $selected")
+
         Button(
-            onClick = { onAddTransaction(amount, selected) },
+            onClick = {
+                // teammate’s callback stays the same (amount + category)
+                // (Later, when team is ready, extend callback to include receiptUri?.toString())
+                onAddTransaction(amount, selected)
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp)
-        ){
+        ) {
             Text("Save")
         }
-        if (AddTransactionError){
+
+        if (AddTransactionError) {
             Text(
                 text = "Failed to add transaction",
                 color = Color.Red,
                 modifier = Modifier.padding(top = 16.dp),
             )
         }
-
     }
 }
 

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
@@ -3,8 +3,32 @@ package com.example.aibudgetapp.ui.screens.transaction
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
 class AddTransactionViewModel : ViewModel() {
+    var amount by mutableIntStateOf(0)
+        private set
 
+    var category by mutableStateOf("Food & Drink")
+        private set
+
+    var receiptUri by mutableStateOf<String?>(null)
+        private set
+
+    fun onAmountChange(input: String) {
+        amount = input.toIntOrNull() ?: 0
+    }
+
+    fun onCategoryChange(value: String) {
+        category = value
+    }
+
+    fun onReceiptSelected(uri: Uri) {
+        receiptUri = uri.toString()
+    }
 }

--- a/app/src/main/res/xml/receipt_paths.xml
+++ b/app/src/main/res/xml/receipt_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="receipt_images" path="images/" />
+</paths>


### PR DESCRIPTION
 Summary
This PR introduces the setup required to support camera/gallery uploads for receipts in the AI Budgeting App.

Changes
- Configured `FileProvider` in AndroidManifest with appropriate authorities.
- Added `receipt_paths.xml` under `res/xml/` to allow temporary receipt images to be stored in cache.
- Integrated with `UploadPhotoButton` to generate temp files for camera/gallery images.
- Declared CAMERA permission and marked camera hardware as optional.

 Notes
- Images are currently stored as **temporary cache files** (`cache-path`). This is intentional so that:
  - No permanent storage is used yet (avoiding DB conflicts).
  - Files can be easily cleaned up by the system.
- Once the database integration is finalized, we can switch from `cache-path` to `files-path` for persistence.

 Impact
- Enables users to attach receipt images from either the camera or gallery when adding a transaction.
- No breaking changes for existing manual transaction entry flow.
