### PR TITLE
Add Budget Overview screen with tabs, dummy data, Pie and Bar charts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,13 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
+    implementation("com.patrykandpatrick.vico:compose:1.13.0")
+    implementation("com.patrykandpatrick.vico:core:1.13.0")
+    implementation("com.patrykandpatrick.vico:compose-m3:1.13.0")
+    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+
+
+
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
@@ -69,5 +76,4 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetOverviewScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetOverviewScreen.kt
@@ -1,0 +1,178 @@
+package com.example.aibudgetapp.ui.screens.budget
+
+import android.graphics.Color
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.github.mikephil.charting.charts.BarChart
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.*
+import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+
+enum class BudgetTab { OVERVIEW, SPENDING, TRANSACTIONS }
+
+@Composable
+fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
+    var selectedTab by remember { mutableStateOf(BudgetTab.OVERVIEW) }
+
+    Scaffold(
+        topBar = {
+            TabRow(selectedTabIndex = selectedTab.ordinal) {
+                Tab(
+                    selected = selectedTab == BudgetTab.OVERVIEW,
+                    onClick = { selectedTab = BudgetTab.OVERVIEW },
+                    text = { Text("Overview") }
+                )
+                Tab(
+                    selected = selectedTab == BudgetTab.SPENDING,
+                    onClick = { selectedTab = BudgetTab.SPENDING },
+                    text = { Text("Spending") }
+                )
+                Tab(
+                    selected = selectedTab == BudgetTab.TRANSACTIONS,
+                    onClick = { selectedTab = BudgetTab.TRANSACTIONS },
+                    text = { Text("Transactions") }
+                )
+            }
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddBudgetClick,
+                containerColor = MaterialTheme.colorScheme.primary
+            ) {
+                Text("+")
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            when (selectedTab) {
+                BudgetTab.OVERVIEW -> {
+                    // Dummy Overview
+                    val totalBudget = 500
+                    val totalSpent = 300
+                    val remaining = totalBudget - totalSpent
+
+                    Text("📊 Budget Overview", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+                        elevation = CardDefaults.cardElevation(4.dp)
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text("Total Budget: $$totalBudget")
+                            Text("Total Spent: $$totalSpent")
+                            Text("Remaining: $$remaining")
+                        }
+                    }
+                }
+
+                BudgetTab.SPENDING -> {
+                    // Spending → Pie + Bar Chart
+                    Text("💰 Spending Breakdown", style = MaterialTheme.typography.titleMedium)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // --- Pie Chart ---
+                    AndroidView(
+                        factory = { context ->
+                            PieChart(context).apply {
+                                val entries = listOf(
+                                    PieEntry(35.7f, "Food & Drink"),
+                                    PieEntry(21.4f, "Entertainment"),
+                                    PieEntry(14.3f, "Gas"),
+                                    PieEntry(28.6f, "Savings")
+                                )
+                                val dataSet = PieDataSet(entries, "").apply {
+                                    colors = listOf(
+                                        Color.RED,
+                                        Color.BLUE,
+                                        Color.YELLOW,
+                                        Color.GREEN
+                                    )
+                                    valueTextSize = 14f
+                                }
+                                this.data = PieData(dataSet)
+                                description.isEnabled = false
+                                legend.isEnabled = true
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(250.dp)
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    // --- Bar Chart ---
+                    AndroidView(
+                        factory = { context ->
+                            BarChart(context).apply {
+                                val entries = listOf(
+                                    BarEntry(0f, 35.7f),
+                                    BarEntry(1f, 21.4f),
+                                    BarEntry(2f, 14.3f),
+                                    BarEntry(3f, 28.6f)
+                                )
+                                val dataSet = BarDataSet(entries, "Categories").apply {
+                                    colors = listOf(
+                                        Color.RED,
+                                        Color.BLUE,
+                                        Color.YELLOW,
+                                        Color.GREEN
+                                    )
+                                    valueTextSize = 14f
+                                }
+                                val data = BarData(dataSet)
+                                this.data = data
+
+                                description.isEnabled = false
+                                xAxis.apply {
+                                    valueFormatter = IndexAxisValueFormatter(
+                                        listOf("Food & Drink", "Entertainment", "Gas", "Savings")
+                                    )
+                                    position = XAxis.XAxisPosition.BOTTOM
+                                    setDrawGridLines(false)
+                                    granularity = 1f
+                                }
+                                axisRight.isEnabled = false
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(250.dp)
+                    )
+                }
+
+                BudgetTab.TRANSACTIONS -> {
+                    // Dummy Transactions
+                    Column {
+                        Text("🧾 Recent Transactions", style = MaterialTheme.typography.titleMedium)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text("- Starbucks Coffee: $5.50")
+                        Text("- Netflix Subscription: $12.99")
+                        Text("- Gas Station: $40.00")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BudgetOverviewScreenPreview() {
+    BudgetOverviewScreen()
+}

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
@@ -27,14 +27,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.TextButton
+
 import com.example.aibudgetapp.ui.screens.screenContainer.ScreenContainerViewModel
+
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BudgetScreen(
-
-){
+    onBackClick: () -> Unit = {}   //added parameter for back
+) {
     val date = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)
     var selecteddate by remember { mutableStateOf(date[0]) }
     val type = listOf("Weekly", "Monthly")
@@ -52,17 +55,32 @@ fun BudgetScreen(
             .fillMaxSize()
             .padding(16.dp),
     ) {
-        Text(
-            text = "New Budget",
-            style = MaterialTheme.typography.bodyLarge,
-        )
+        // Top bar with Back button + Title
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TextButton(onClick = { onBackClick() }) {
+                Text("Back")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "New Budget",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        //  existing form starts here
         OutlinedTextField(
             value = name,
             onValueChange = { name = it },
-            label = {Text("Name")},
+            label = { Text("Name") },
             modifier = Modifier.fillMaxWidth(),
-            )
+        )
         Spacer(modifier = Modifier.height(20.dp))
+
         ExposedDropdownMenuBox(
             expanded = isDateExpanded,
             onExpandedChange = { isDateExpanded = !isDateExpanded },
@@ -89,7 +107,6 @@ fun BudgetScreen(
         }
 
         Text(text = "Currently selected: $selecteddate")
-
 
         ExposedDropdownMenuBox(
             expanded = isTypeExpanded,
@@ -119,18 +136,20 @@ fun BudgetScreen(
         Text(text = "Currently selected: $chosentype")
 
         Spacer(modifier = Modifier.height(20.dp))
+
         OutlinedTextField(
             value = amount.toString(),
             onValueChange = { amount = it.toIntOrNull() ?: 0 },
             label = { Text("Amount") },
             modifier = Modifier.fillMaxWidth(),
         )
+
         Spacer(modifier = Modifier.height(20.dp))
 
-        Row (
+        Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Start,
-        ){
+        ) {
             Text("Include savings transfers")
             Spacer(modifier = Modifier.width(140.dp))
             Switch(
@@ -138,10 +157,9 @@ fun BudgetScreen(
                 onCheckedChange = { checked = it }
             )
         }
-
     }
-
 }
+
 @Preview(showBackground = true)
 @Composable
 fun AppPreview() {

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainer.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainer.kt
@@ -11,8 +11,10 @@ import com.example.aibudgetapp.ui.screens.settings.SettingsScreen
 import com.example.aibudgetapp.ui.screens.budget.BudgetScreen
 import com.example.aibudgetapp.ui.screens.transaction.AddTransactionScreen
 import com.example.aibudgetapp.ui.theme.*
+import com.example.aibudgetapp.ui.screens.budget.BudgetOverviewScreen
 
-enum class Screen { HOME, ADDTRANSACTION, SETTINGS, BUDGET }
+
+enum class Screen { HOME, ADDTRANSACTION, SETTINGS, BUDGETOVERVIEW, BUDGET } // BUDGETOVERVIEW
 
 @Composable
 fun ScreenContainer(userName: String) {
@@ -23,7 +25,8 @@ fun ScreenContainer(userName: String) {
             bottomBar = {
                 BottomNavBar(
                     onHomeClick = { screenContainerViewModel.navigateTo(Screen.HOME) },
-                    onBudgetClick = { screenContainerViewModel.navigateTo(Screen.BUDGET) },
+                    // now points to overview, not directly to form
+                    onBudgetClick = { screenContainerViewModel.navigateTo(Screen.BUDGETOVERVIEW) },
                     onSettingsClick = { screenContainerViewModel.navigateTo(Screen.SETTINGS) }
                 )
             }
@@ -32,13 +35,25 @@ fun ScreenContainer(userName: String) {
                 when (screenContainerViewModel.currentScreen) {
                     Screen.HOME -> HomeScreen(
                         userName = userName,
-                        screenContainerViewModel = screenContainerViewModel,)
+                        screenContainerViewModel = screenContainerViewModel,
+                    )
                     Screen.ADDTRANSACTION -> AddTransactionScreen(
-                        onAddTransaction = {amount, category -> screenContainerViewModel.addTransaction(amount, category) },
+                        onAddTransaction = { amount, category ->
+                            screenContainerViewModel.addTransaction(amount, category)
+                        },
                         AddTransactionError = screenContainerViewModel.addTransactionError
                     )
                     Screen.SETTINGS -> SettingsScreen()
-                    Screen.BUDGET -> BudgetScreen()
+
+                    //  New overview screen with tabs + FAB
+                    Screen.BUDGETOVERVIEW -> BudgetOverviewScreen(
+                        onAddBudgetClick = { screenContainerViewModel.navigateTo(Screen.BUDGET) }
+                    )
+
+                    // Form screen with Back button
+                    Screen.BUDGET -> BudgetScreen(
+                        onBackClick = { screenContainerViewModel.navigateTo(Screen.BUDGETOVERVIEW) }
+                    )
                 }
             }
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io") // Added for MPAndroidChart
     }
 }
 


### PR DESCRIPTION
- Implemented BudgetOverviewScreen with 3 tabs: Overview, Spending, Transactions
- Overview tab: shows dummy budget summary (total, spent, remaining) inside a card
- Spending tab: added MPAndroidChart PieChart and BarChart with sample category data
- Transactions tab: displays a simple list of dummy transactions
- Integrated floating action button (+) for adding budgets
- Added proper imports and dependencies for MPAndroidChart
- Verified layout renders correctly with Compose + AndroidView interoperability