### PR TITLE
feat: implement Firestore write functionality on budget and transaction

### DIFF
--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetRepository.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetRepository.kt
@@ -1,15 +1,20 @@
 package com.example.aibudgetapp.ui.screens.budget
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 
 class BudgetRepository {
-    private val budgetdatabase = Firebase.firestore
+    private val db = Firebase.firestore
+    private val auth = Firebase.auth
+
+    private fun userBudgetsRef() = db
+        .collection("users")
+        .document(auth.currentUser?.uid ?: throw IllegalStateException("Not logged in"))
+        .collection("budgets")
 
     fun addBudget(budget: Budget, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
-        val budgetmap = hashMapOf(
+        val map = hashMapOf(
             "name" to budget.name,
             "selecteddate" to budget.selecteddate,
             "chosentype" to budget.chosentype,
@@ -17,9 +22,9 @@ class BudgetRepository {
             "amount" to budget.amount,
             "checked" to budget.checked,
         )
-        budgetdatabase.collection("budgets")
-            .add(budgetmap)
-            .addOnSuccessListener { onSuccess()}
-            .addOnFailureListener { e -> onFailure(e)}
+        userBudgetsRef()
+            .add(map)
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { e -> onFailure(e) }
     }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
@@ -1,5 +1,6 @@
 package com.example.aibudgetapp.ui.screens.budget
 
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,20 +30,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.TextButton
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.graphics.Color
+import com.example.aibudgetapp.ui.screens.login.LoginViewModel
 
 import com.example.aibudgetapp.ui.screens.screenContainer.ScreenContainerViewModel
-
+import kotlin.getValue
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BudgetScreen(
-    onAddBudget: (String, Int, String, String, Int, Boolean) -> Unit,
     onBackClick: () -> Unit = {},  //added parameter for back
-    budgetError: Boolean,
 
 ) {
+    val budgetViewModel = remember { BudgetViewModel(BudgetRepository()) }
+    val budgetError by remember { derivedStateOf { budgetViewModel.budgetError } }
+
     val date = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)
     var selecteddate by remember { mutableStateOf(date[0]) }
     val type = listOf("Weekly", "Monthly")
@@ -193,7 +197,7 @@ fun BudgetScreen(
             )
         }
         Button(
-            onClick = { onAddBudget(name, selecteddate, chosentype, chosencategory, amount, checked) },
+            onClick = { budgetViewModel.onAddBudget(name, selecteddate, chosentype, chosencategory, amount, checked) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp)

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
@@ -1,8 +1,40 @@
 package com.example.aibudgetapp.ui.screens.budget
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
-class BudgetViewModel(private val repository: BudgetRepository): ViewModel() {
+class BudgetViewModel(
+    private val repository: BudgetRepository): ViewModel() {
 
+    var budgetError by mutableStateOf(false)
+        private set
 
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+
+    fun addBudget(b: Budget) {
+        repository.addBudget(
+            budget = b,
+            onSuccess = { budgetError = false },
+            onFailure = { e -> errorMessage = e.message; budgetError = true }
+        )
+    }
+
+    fun onAddBudget(name: String, selecteddate: Int, chosentype: String, chosencategory: String, amount: Int, checked: Boolean){
+        if (amount <= 0 || name.isBlank()) {
+            budgetError = true
+        } else{
+            val budget = Budget(
+                name = name,
+                selecteddate = selecteddate,
+                chosentype = chosentype,
+                chosencategory = chosencategory,
+                amount = amount,
+                checked = checked
+            )
+            addBudget(budget)
+        }
+    }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/login/LoginViewModel.kt
@@ -25,6 +25,9 @@ class LoginViewModel : ViewModel() {
     var loginErrorMessage by mutableStateOf<String?>(null)
         private set
 
+    var currentUid by mutableStateOf<String?>(null)
+        private set
+
     private fun mapAuthErrorShort(e: Exception): String = when (e) {
         is FirebaseAuthInvalidCredentialsException,
         is FirebaseAuthInvalidUserException -> "Invalid email or password."
@@ -41,6 +44,7 @@ class LoginViewModel : ViewModel() {
                     isLoggedIn = true
                     loginError = false
                     loginErrorMessage = null
+                    currentUid = user?.uid
                     userName = user?.email ?: ""
                 } else {
                     // Login failed

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainer.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainer.kt
@@ -37,12 +37,7 @@ fun ScreenContainer(userName: String) {
                         userName = userName,
                         screenContainerViewModel = screenContainerViewModel,
                     )
-                    Screen.ADDTRANSACTION -> AddTransactionScreen(
-                        onAddTransaction = { amount, category ->
-                            screenContainerViewModel.addTransaction(amount, category)
-                        },
-                        AddTransactionError = screenContainerViewModel.addTransactionError
-                    )
+                    Screen.ADDTRANSACTION -> AddTransactionScreen()
                     Screen.SETTINGS -> SettingsScreen()
 
                     //  New overview screen with tabs + FAB
@@ -52,11 +47,7 @@ fun ScreenContainer(userName: String) {
 
                     // Form screen with Back button
                     Screen.BUDGET -> BudgetScreen(
-                        onBackClick = { screenContainerViewModel.navigateTo(Screen.BUDGETOVERVIEW) },
-                        onAddBudget = { name, selecteddate, chosentype, chosencategory, amount, checked ->
-                            screenContainerViewModel.addBudget( name, selecteddate, chosentype, chosencategory, amount, checked) },
-                        budgetError = screenContainerViewModel.budgetError,
-
+                        onBackClick = { screenContainerViewModel.navigateTo(Screen.BUDGETOVERVIEW) }
                     )
                 }
             }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainerViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/screenContainer/ScreenContainerViewModel.kt
@@ -14,23 +14,4 @@ class ScreenContainerViewModel {
     var addTransactionError by mutableStateOf(false)
         private set
 
-    var budgetError by mutableStateOf(false)
-        private set
-    var budgetErrorMessage by mutableStateOf<String?>(null)
-        private set
-
-    fun addTransaction(amount: Int, category: String) {
-        if (amount <= 0 || category.isBlank()) {
-            addTransactionError = true
-        } else {
-            addTransactionError = false
-        }
-    }
-    fun addBudget(name: String, selecteddate: Int, chosentype: String, chosencategory: String, amount: Int, checked: Boolean){
-        if (amount <= 0 || name.isBlank()) {
-            budgetError = true
-        } else {
-            budgetError = false
-        }
-    }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionScreen.kt
@@ -11,16 +11,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import com.example.aibudgetapp.ui.components.UploadPhotoButton   // NEW
+import com.example.aibudgetapp.ui.screens.budget.BudgetRepository
+import com.example.aibudgetapp.ui.screens.budget.BudgetViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddTransactionScreen(
-    onAddTransaction: (Int, String) -> Unit,
-    AddTransactionError: Boolean
-) {
+fun AddTransactionScreen() {
+    val addTransactionViewModel = remember { AddTransactionViewModel(TransactionRepository()) }
+    val transactionError by remember { derivedStateOf { addTransactionViewModel.transactionError } }
     val list = listOf("Food & Drink", "Rent", "Gas", "Other")
     var selected by remember { mutableStateOf(list[0]) }
-    var amount by remember { mutableIntStateOf(0) }
+    var amount by remember { mutableDoubleStateOf(0.00) }
     var isExpanded by remember { mutableStateOf(false) }
 
     // hold the chosen image locally (no DB / VM needed yet)
@@ -54,7 +55,7 @@ fun AddTransactionScreen(
 
         OutlinedTextField(
             value = amount.toString(),
-            onValueChange = { amount = it.toIntOrNull() ?: 0 },
+            onValueChange = { amount = (it.toDoubleOrNull() ?: 0) as Double },
             label = { Text("Amount") },
             modifier = Modifier.fillMaxWidth(),
         )
@@ -90,7 +91,7 @@ fun AddTransactionScreen(
             onClick = {
                 // teammate’s callback stays the same (amount + category)
                 // (Later, when team is ready, extend callback to include receiptUri?.toString())
-                onAddTransaction(amount, selected)
+                addTransactionViewModel.onAddTransaction("", "", amount, selected)
             },
             modifier = Modifier
                 .fillMaxWidth()
@@ -99,7 +100,7 @@ fun AddTransactionScreen(
             Text("Save")
         }
 
-        if (AddTransactionError) {
+        if (transactionError) {
             Text(
                 text = "Failed to add transaction",
                 color = Color.Red,
@@ -112,10 +113,5 @@ fun AddTransactionScreen(
 @Preview(showBackground = true)
 @Composable
 fun AddTransactionScreenPreview() {
-    AddTransactionScreen(
-        onAddTransaction = { amount, category ->
-            println("Transaction added: Amount = $amount, Category = $category")
-        },
-        AddTransactionError = false
-    )
+    AddTransactionScreen()
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
@@ -9,8 +9,11 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.github.mikephil.charting.components.Description
 
-class AddTransactionViewModel : ViewModel() {
+
+class AddTransactionViewModel(
+    private val repository: TransactionRepository) : ViewModel() {
     var amount by mutableIntStateOf(0)
         private set
 
@@ -18,6 +21,9 @@ class AddTransactionViewModel : ViewModel() {
         private set
 
     var receiptUri by mutableStateOf<String?>(null)
+        private set
+
+    var transactionError by mutableStateOf(false)
         private set
 
     fun onAmountChange(input: String) {
@@ -30,5 +36,27 @@ class AddTransactionViewModel : ViewModel() {
 
     fun onReceiptSelected(uri: Uri) {
         receiptUri = uri.toString()
+    }
+
+    fun addTransaction(t: Transaction){
+        repository.addTransaction(
+            transaction = t,
+            onSuccess = {transactionError = false},
+            onFailure = {transactionError = true}
+        )
+    }
+
+    fun onAddTransaction(id: String, description: String, amount: Double, category: String) {
+        if (amount <= 0 || category.isBlank()) {
+            transactionError = true
+        } else {
+            val transaction = Transaction(
+                id = id,
+                description = description,
+                amount = amount,
+                category = category
+            )
+            addTransaction(t = transaction)
+        }
     }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/TransactionRepository.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/TransactionRepository.kt
@@ -1,0 +1,29 @@
+package com.example.aibudgetapp.ui.screens.transaction
+
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.firestore.firestore
+
+class TransactionRepository {
+
+    private val db = Firebase.firestore
+    private val auth = Firebase.auth
+
+    private fun userTransactionRef() = db
+        .collection("users")
+        .document(auth.currentUser?.uid ?: throw IllegalStateException("Not logged in"))
+        .collection("transactions")
+
+    fun addTransaction(transaction: Transaction, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+        val map = hashMapOf(
+            "id" to transaction.id,
+            "description" to transaction.description,
+            "amount" to transaction.amount,
+            "category" to transaction.category,
+        )
+        userTransactionRef()
+            .add(map)
+            .addOnSuccessListener { onSuccess() }
+            .addOnFailureListener { e -> onFailure(e) }
+    }
+}


### PR DESCRIPTION
Implemented BudgetRepository with addBudget() to save budget data to Firestore.
Implemented TransactionRepository with addTransaction() to save transaction data to Firestore.
Configured Firestore references scoped to the authenticated user (users/{uid}/...).
Updated Firestore security rules to ensure only the authenticated user can access their own data.

Notes
Currently supports write operations (create).
Read method will be added in upcoming commits.
Collection names follow convention: budgets and transactions.