### PR TITLE
Feature/budget end date feat: add budget end date logic + CSV import for transactions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,4 +107,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation("androidx.compose.runtime:runtime-livedata")
+
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/components/UploadPhotoButton.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/components/UploadPhotoButton.kt
@@ -111,12 +111,11 @@ fun UploadPhotoButton(
     ) { uri: Uri? ->
         uri?.let {
             val transactions = parseCsv(context, it)
-            transactions.forEach { tx ->
-                android.util.Log.d("CSV_IMPORT", "Parsed transaction: $tx")
-            }
+            addTxViewModel.importTransactions(transactions)
             Toast.makeText(context, "CSV imported (${transactions.size})", Toast.LENGTH_SHORT).show()
         }
     }
+
 
     val takePictureLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture()

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/AddBudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/AddBudgetScreen.kt
@@ -41,6 +41,9 @@ fun BudgetScreen(
     val budgetViewModel = remember { BudgetViewModel(BudgetRepository()) }
     val budgetError by remember { derivedStateOf { budgetViewModel.budgetError } }
     val budgetSuccess by remember { derivedStateOf { budgetViewModel.budgetSuccess } }
+    var startDate by remember { mutableStateOf("") }
+    var endDate by remember { mutableStateOf("") }
+
 
     val date = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)
     // var selectedDate by remember { mutableStateOf(date[0]) }
@@ -85,6 +88,22 @@ fun BudgetScreen(
             onValueChange = { name = it
                 budgetViewModel.budgetSuccess = false },
             label = { Text("Name") },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+
+        OutlinedTextField(
+            value = startDate,
+            onValueChange = { startDate = it },
+            label = { Text("Start Date (yyyy-mm-dd)") },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = endDate,
+            onValueChange = { endDate = it },
+            label = { Text("End Date (yyyy-mm-dd)") },
             modifier = Modifier.fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(20.dp))
@@ -194,7 +213,7 @@ fun BudgetScreen(
             )
         }
         Button(
-            onClick = { budgetViewModel.onAddBudget(name, chosenType, chosenCategory, amount, checked) },
+            onClick = { budgetViewModel.onAddBudget(name, chosenType, chosenCategory, amount, checked, startDate, endDate) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp)

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/Budget.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/Budget.kt
@@ -8,4 +8,6 @@ data class Budget (
     val chosenCategory: String,
     val amount: Int,
     val checked: Boolean,
+    val startDate: String? = null,
+    val endDate: String? = null
 )

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetItemCard.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetItemCard.kt
@@ -25,6 +25,8 @@ fun BudgetItemCard(budget: Budget) {
             Text(text = "Category: ${budget.chosenCategory}", style = MaterialTheme.typography.bodySmall)
             Text(text = "Type: ${budget.chosenType}", style = MaterialTheme.typography.bodySmall)
             // Text(text = "Date: ${budget.selectedDate}", style = MaterialTheme.typography.bodySmall)
+            Text(text = "From: ${budget.startDate}", style = MaterialTheme.typography.bodySmall)
+            Text(text = "To: ${budget.endDate}", style = MaterialTheme.typography.bodySmall)
         }
     }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetRepository.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetRepository.kt
@@ -26,6 +26,8 @@ class BudgetRepository {
             "chosencategory" to budget.chosenCategory,
             "amount" to budget.amount,
             "checked" to budget.checked,
+            "startDate" to (budget.startDate ?: ""),
+            "endDate" to (budget.endDate ?: "")
         )
         userBudgetsRef()
             .add(map)
@@ -54,9 +56,13 @@ class BudgetRepository {
                             chosenType = data["chosentype"] as? String ?: "",
                             chosenCategory = data["chosencategory"] as? String ?: "",
                             amount = (data["amount"] as? Number)?.toInt() ?: 0,
-                            checked = data["checked"] as? Boolean ?: false
+                            checked = data["checked"] as? Boolean ?: false,
+                            startDate = data["startDate"] as? String,
+                            endDate = data["endDate"] as? String
                         )
                     }
+                    Log.d("REPO", "getBudgets: found ${list.size} budgets")
+
                     onSuccess(list)
                 }
                 .addOnFailureListener(onFailure)
@@ -82,7 +88,7 @@ class BudgetRepository {
     }
     fun getbudgetcategory(
         category: String,
-        onSuccess: (List<Budget>) -> Unit,
+    onSuccess: (List<Budget>) -> Unit,
         onFailure: (Exception) -> Unit
     ){
         try {
@@ -99,9 +105,14 @@ class BudgetRepository {
                         chosenType = cate["chosentype"] as? String ?: "",
                         chosenCategory = cate["chosencategory"] as? String ?: "",
                         amount = (cate["amount"] as? Number)?.toInt() ?: 0,
-                        checked = cate["checked"] as? Boolean ?: false
+                        checked = cate["checked"] as? Boolean ?: false,
+                        startDate = cate["startDate"] as? String,
+                        endDate = cate["endDate"] as? String
                     )
                 }
+                Log.d("REPO", "getBudgets: found ${results.size} budgets")
+
+
                 onSuccess(results)
             }
             .addOnFailureListener(onFailure)

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
@@ -4,22 +4,44 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.aibudgetapp.ui.screens.transaction.TransactionRepository
 import com.example.aibudgetapp.ui.screens.transaction.AddTransactionViewModel
+import com.example.aibudgetapp.ui.screens.transaction.TransactionRepository
 import com.example.aibudgetapp.ui.screens.transaction.AddTransactionViewModelFactory
 import androidx.lifecycle.viewmodel.compose.viewModel
-
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.tooling.preview.Preview
 
 enum class BudgetTab { OVERVIEW, SPENDING, TRANSACTIONS }
 
 @Composable
 fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
+    // Transaction ViewModel
     val repository = TransactionRepository()
-    val viewModel: AddTransactionViewModel = viewModel(
+    val transactionViewModel: AddTransactionViewModel = viewModel(
         factory = AddTransactionViewModelFactory(repository)
     )
+
+    //  Shared Budget ViewModel (using the Factory inside BudgetViewModel.kt)
+    val budgetViewModel: BudgetViewModel = viewModel(
+        factory = BudgetViewModel.Factory(BudgetRepository())
+    )
+
+    // Always fetch budgets when screen opens
+    LaunchedEffect(Unit) { budgetViewModel.fetchBudgets() }
+
+    // Observe budget list
+    val budgets by budgetViewModel.budgetList.observeAsState(emptyList())
+
+    // Currently selected budget
+    var selectedBudget by remember { mutableStateOf<Budget?>(null) }
+    LaunchedEffect(budgets) {
+        if (selectedBudget == null && budgets.isNotEmpty()) {
+            selectedBudget = budgets.first()
+        }
+    }
+
+    // Tab selection
     var selectedTab by remember { mutableStateOf(BudgetTab.OVERVIEW) }
 
     Scaffold(
@@ -46,9 +68,7 @@ fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
             FloatingActionButton(
                 onClick = onAddBudgetClick,
                 containerColor = MaterialTheme.colorScheme.primary
-            ) {
-                Text("+")
-            }
+            ) { Text("+") }
         }
     ) { innerPadding ->
         Column(
@@ -57,17 +77,56 @@ fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
                 .padding(innerPadding)
                 .padding(16.dp)
         ) {
+            //  Budget selector only on Spending tab
+            if (selectedTab == BudgetTab.SPENDING && budgets.isNotEmpty()) {
+                var expanded by remember { mutableStateOf(false) }
+                Box {
+                    Button(onClick = { expanded = true }, modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            selectedBudget?.let { "${it.name} (${it.chosenType})" }
+                                ?: "Select Budget"
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        budgets.forEach { budget ->
+                            DropdownMenuItem(
+                                text = { Text("${budget.name} (${budget.chosenType})") },
+                                onClick = {
+                                    selectedBudget = budget
+                                    expanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+                selectedBudget?.let {
+                    Text(
+                        "Current:\nName: ${it.name}\nType: ${it.chosenType}\nCategory: ${it.chosenCategory}\nAmount: $${it.amount}",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                } ?: Text("No budget selected")
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            //  Tab contents
             when (selectedTab) {
                 BudgetTab.OVERVIEW -> {
+                    //  if you want Overview to use the same ViewModel, pass budgetViewModel here
                     OverviewScreen()
                 }
-
                 BudgetTab.SPENDING -> {
-                    SpendingScreen(viewModel)
+                    selectedBudget?.let {
+                        SpendingScreen(
+                            addTransactionViewModel = transactionViewModel,
+                            selectedBudget = it
+                        )
+                    } ?: Text("Please select a budget to view spending")
                 }
-
                 BudgetTab.TRANSACTIONS -> {
-                    TransactionsScreen(viewModel = viewModel)
+                    TransactionsScreen(viewModel = transactionViewModel)
                 }
             }
         }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
@@ -53,18 +53,19 @@ fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
                     text = { Text("Overview") }
                 )
                 Tab(
-                    selected = selectedTab == BudgetTab.SPENDING,
-                    onClick = { selectedTab = BudgetTab.SPENDING },
-                    text = { Text("Spending") }
-                )
-                Tab(
                     selected = selectedTab == BudgetTab.TRANSACTIONS,
                     onClick = { selectedTab = BudgetTab.TRANSACTIONS },
                     text = { Text("Transactions") }
                 )
+                Tab(
+                    selected = selectedTab == BudgetTab.SPENDING,
+                    onClick = { selectedTab = BudgetTab.SPENDING },
+                    text = { Text("Spending") }
+                )
             }
         },
-        floatingActionButton = {
+
+                floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddBudgetClick,
                 containerColor = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetScreen.kt
@@ -53,14 +53,14 @@ fun BudgetOverviewScreen(onAddBudgetClick: () -> Unit = {}) {
                     text = { Text("Overview") }
                 )
                 Tab(
-                    selected = selectedTab == BudgetTab.TRANSACTIONS,
-                    onClick = { selectedTab = BudgetTab.TRANSACTIONS },
-                    text = { Text("Transactions") }
-                )
-                Tab(
                     selected = selectedTab == BudgetTab.SPENDING,
                     onClick = { selectedTab = BudgetTab.SPENDING },
                     text = { Text("Spending") }
+                )
+                Tab(
+                    selected = selectedTab == BudgetTab.TRANSACTIONS,
+                    onClick = { selectedTab = BudgetTab.TRANSACTIONS },
+                    text = { Text("Transactions") }
                 )
             }
         },

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
@@ -36,22 +36,32 @@ class BudgetViewModel(
         )
     }
 
-    fun onAddBudget(name: String, chosentype: String, chosencategory: String, amount: Int, checked: Boolean){
+    fun onAddBudget(
+        name: String,
+        chosentype: String,
+        chosencategory: String,
+        amount: Int,
+        checked: Boolean,
+        startDate: String?,
+        endDate: String?
+    ) {
         if (amount <= 0 || name.isBlank()) {
             budgetError = true
-        } else{
+        } else {
             val budget = Budget(
                 id = "",
                 name = name,
-                // selectedDate = selecteddate,
                 chosenType = chosentype,
                 chosenCategory = chosencategory,
                 amount = amount,
-                checked = checked
+                checked = checked,
+                startDate = startDate,
+                endDate = endDate
             )
             addBudget(budget)
         }
     }
+
 
     fun fetchBudgets() {
         isLoading = true

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/BudgetViewModel.kt
@@ -6,9 +6,14 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import java.time.LocalDate
+import com.example.aibudgetapp.ui.screens.transaction.Transaction
+import androidx.lifecycle.ViewModelProvider
+
 
 class BudgetViewModel(
-    private val repository: BudgetRepository): ViewModel() {
+    private val repository: BudgetRepository
+) : ViewModel() {
 
     var budgetError by mutableStateOf(false)
         private set
@@ -21,11 +26,12 @@ class BudgetViewModel(
     var isLoading by mutableStateOf(false)
         private set
 
+    // existing mutableState list
     var budgets by mutableStateOf<List<Budget>>(emptyList())
         private set
 
-    val _budgetList = MutableLiveData<List<Budget>>()
-
+    // LiveData-backed list
+    private val _budgetList = MutableLiveData<List<Budget>>()
     val budgetList: LiveData<List<Budget>> = _budgetList
 
     fun addBudget(b: Budget) {
@@ -62,7 +68,6 @@ class BudgetViewModel(
         }
     }
 
-
     fun fetchBudgets() {
         isLoading = true
         budgetError = false
@@ -70,6 +75,7 @@ class BudgetViewModel(
         repository.getBudgets(
             onSuccess = { list ->
                 budgets = list
+                _budgetList.value = list   // 🔹 keep LiveData in sync
                 isLoading = false
             },
             onFailure = { e ->
@@ -86,10 +92,11 @@ class BudgetViewModel(
             onFailure = { budgetError = true }
         )
     }
-    fun fetchbudgetcategory(category: String){
+
+    fun fetchbudgetcategory(category: String) {
         repository.getbudgetcategory(
             category = category,
-            onSuccess = {budgets ->
+            onSuccess = { budgets ->
                 _budgetList.value = budgets
             },
             onFailure = { e ->
@@ -98,4 +105,40 @@ class BudgetViewModel(
         )
     }
 
+    fun getBudgetPieChartData(
+        budget: Budget,
+        transactions: List<Transaction>
+    ): List<Pair<String, Float>> {
+        val filtered = transactions.filter {
+            it.category == budget.chosenCategory &&
+                    !budget.startDate.isNullOrBlank() && !budget.endDate.isNullOrBlank() &&
+                    LocalDate.parse(it.date) >= LocalDate.parse(budget.startDate) &&
+                    LocalDate.parse(it.date) <= LocalDate.parse(budget.endDate)
+        }
+        val spent = filtered.sumOf { it.amount ?: 0.0 }
+        val remaining = (budget.amount - spent).coerceAtLeast(0.0)
+        return if (spent > budget.amount) {
+            listOf(
+                "Budget" to budget.amount.toFloat(),
+                "Overspent" to (spent - budget.amount).toFloat()
+            )
+        } else {
+            listOf(
+                "Spent" to spent.toFloat(),
+                "Remaining" to remaining.toFloat()
+            )
+        }
+    }
+
+    class Factory(
+        private val repository: BudgetRepository
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(BudgetViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return BudgetViewModel(repository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/OverviewScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/OverviewScreen.kt
@@ -74,10 +74,10 @@ fun OverviewScreen(
     }
 
     Button(
-    onClick = { budgetViewModel.fetchBudgets() },
-    modifier = Modifier
-    .fillMaxWidth()
-    .padding(top = 16.dp)
+        onClick = { budgetViewModel.fetchBudgets() },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp)
     ) {
         Text("read budgets")
     }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/PieChart.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/PieChart.kt
@@ -1,0 +1,67 @@
+package com.example.aibudgetapp.ui.screens.budget
+
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.PieData
+import com.github.mikephil.charting.data.PieDataSet
+import com.github.mikephil.charting.data.PieEntry
+import com.github.mikephil.charting.components.Legend
+
+/**
+ * Generic Pie Chart Composable to show budget vs. spending slices.
+ *
+ * @param dataPairs List of Pair(label, value) for chart slices, e.g. ("Spent", 7000f), ("Remaining", 3000f).
+ * @param modifier Modifier for Compose UI layout.
+ */
+@Composable
+fun BudgetPieChart(
+    dataPairs: List<Pair<String, Float>>,
+    modifier: Modifier = Modifier
+) {
+    val colorPalette = listOf(
+        MaterialTheme.colorScheme.primary.toArgb(),
+        MaterialTheme.colorScheme.secondary.toArgb(),
+        MaterialTheme.colorScheme.tertiary.toArgb(),
+        MaterialTheme.colorScheme.surface.toArgb(),
+        MaterialTheme.colorScheme.onPrimary.toArgb(),
+        MaterialTheme.colorScheme.onSecondary.toArgb()
+    )
+
+    AndroidView(
+        factory = { context ->
+            PieChart(context).apply {
+                val entries = dataPairs.map { (label, value) ->
+                    PieEntry(value, label)
+                }
+                val dataSet = PieDataSet(entries, "").apply {
+                    colors = colorPalette
+                    valueTextSize = 16f
+                    sliceSpace = 4f
+                }
+                this.data = PieData(dataSet)
+                description.isEnabled = false
+                legend.apply {
+                    isEnabled = true
+                    textSize = 14f
+                    verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
+                    horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
+                    orientation = Legend.LegendOrientation.HORIZONTAL
+                    xEntrySpace = 20f
+                }
+                setUsePercentValues(true)
+                setDrawEntryLabels(true)
+                setEntryLabelTextSize(14f)
+                setExtraOffsets(10f, 10f, 10f, 10f)
+                animateY(1200)
+                invalidate()
+            }
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/SpendingScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/SpendingScreen.kt
@@ -1,7 +1,5 @@
 package com.example.aibudgetapp.ui.screens.budget
 
-
-
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -14,20 +12,106 @@ import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.charts.PieChart
 import com.github.mikephil.charting.components.Legend
 import com.github.mikephil.charting.components.XAxis
-import com.github.mikephil.charting.data.BarData
-import com.github.mikephil.charting.data.BarDataSet
-import com.github.mikephil.charting.data.BarEntry
-import com.github.mikephil.charting.data.PieData
-import com.github.mikephil.charting.data.PieDataSet
-import com.github.mikephil.charting.data.PieEntry
+import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
 import com.example.aibudgetapp.ui.screens.transaction.AddTransactionViewModel
-
-
+import java.time.LocalDate
 
 @Composable
-fun SpendingScreen(addTransactionViewModel: AddTransactionViewModel) {
+fun SpendingScreen(
+    addTransactionViewModel: AddTransactionViewModel,
+    selectedBudget: Budget
+) {
     val spending = addTransactionViewModel.spendingByCategory.collectAsState(initial = emptyMap())
+
+    // --- Helper for safe date parsing ---
+    val safeParse: (String?) -> LocalDate? = { dateStr ->
+        try { dateStr?.replace("/", "-")?.let { LocalDate.parse(it) } }
+        catch (e: Exception) { null }
+    }
+
+    // --- Filter transactions by budget date range ---
+    val filteredTxns = addTransactionViewModel.transactions.filter { tx ->
+        val txDate = safeParse(tx.date)
+        val start = safeParse(selectedBudget.startDate)
+        val end = safeParse(selectedBudget.endDate)
+        txDate != null && start != null && end != null && (txDate >= start && txDate <= end)
+    }
+
+    // --- Calculate totals ---
+    val totalSpent = filteredTxns.sumOf { it.amount ?: 0.0 }
+    val budgetAmount = selectedBudget.amount
+    val overspent = if (totalSpent > budgetAmount) totalSpent - budgetAmount else 0.0
+    val saving = if (totalSpent < budgetAmount) budgetAmount - totalSpent else 0.0
+
+    // --- Pie chart slices ---
+    val pieSlices = mutableListOf<Pair<String, Float>>().apply {
+        add("Budget" to budgetAmount.toFloat())
+        add("Spending" to totalSpent.toFloat())
+        if (overspent > 0) {
+            add("Overspent" to overspent.toFloat())
+        } else {
+            add("Saving" to saving.toFloat())
+        }
+    }
+
+    val colorPalette = listOf(
+        MaterialTheme.colorScheme.primary.toArgb(),
+        MaterialTheme.colorScheme.secondary.toArgb(),
+        MaterialTheme.colorScheme.tertiary.toArgb(),
+        MaterialTheme.colorScheme.error.toArgb() // red for overspent
+    )
+
+    Spacer(modifier = Modifier.height(32.dp))
+    Text("Budget vs Spending", style = MaterialTheme.typography.titleMedium)
+
+    // ---- Pie Chart ----
+    AndroidView(
+        factory = { context ->
+            PieChart(context).apply {
+                val entries = pieSlices.map { (label, value) -> PieEntry(value, label) }
+                val dataSet = PieDataSet(entries, "").apply {
+                    colors = colorPalette
+                    valueTextSize = 16f
+                    sliceSpace = 4f
+                }
+                this.data = PieData(dataSet)
+                description.isEnabled = false
+                legend.apply {
+                    isEnabled = true
+                    textSize = 14f
+                    verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
+                    horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
+                    orientation = Legend.LegendOrientation.HORIZONTAL
+                    xEntrySpace = 20f
+                }
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(250.dp)
+    )
+
+    // Show remaining/overspent text
+    Spacer(modifier = Modifier.height(8.dp))
+    if (overspent > 0) {
+        Text(
+            text = "Overspent by $overspent",
+            color = MaterialTheme.colorScheme.error
+        )
+    } else {
+        Text(
+            text = "Remaining to save: $saving",
+            color = MaterialTheme.colorScheme.primary
+        )
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    
+
+
+    // ---- Bar Chart: Per-category spending ----
     val maxCategoriesToShow = 6
     val sortedEntries = spending.value.entries.sortedByDescending { it.value }
     val topSpending = sortedEntries.take(maxCategoriesToShow)
@@ -37,75 +121,33 @@ fun SpendingScreen(addTransactionViewModel: AddTransactionViewModel) {
     else
         topSpending.map { it.key to it.value }
 
-    val colorPalette = listOf(
-        MaterialTheme.colorScheme.primary.toArgb(),
-        MaterialTheme.colorScheme.secondary.toArgb(),
-        MaterialTheme.colorScheme.tertiary.toArgb(),
-        MaterialTheme.colorScheme.surface.toArgb(),
-        MaterialTheme.colorScheme.onPrimary.toArgb(),
-        MaterialTheme.colorScheme.onSecondary.toArgb(),
-        MaterialTheme.colorScheme.onTertiary.toArgb()
+    AndroidView(
+        factory = { context ->
+            BarChart(context).apply {
+                val entries = displaySpending.mapIndexed { idx, entry ->
+                    BarEntry(idx.toFloat(), entry.second.toFloat())
+                }
+                val dataSet = BarDataSet(entries, "Categories").apply {
+                    colors = colorPalette
+                    valueTextSize = 16f
+                }
+                val data = BarData(dataSet)
+                this.data = data
+                description.isEnabled = false
+                xAxis.apply {
+                    valueFormatter = IndexAxisValueFormatter(displaySpending.map { it.first })
+                    position = XAxis.XAxisPosition.BOTTOM
+                    setDrawGridLines(false)
+                    granularity = 1f
+                    textSize = 12f
+                    labelRotationAngle = -45f
+                }
+                axisRight.isEnabled = false
+                legend.isEnabled = false
+            }
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(250.dp)
     )
-
-    Spacer(modifier = Modifier.height(32.dp))
-    Text("Live Spending by Category", style = MaterialTheme.typography.titleMedium)
-    if (displaySpending.isEmpty()) {
-        Text("No spending records yet.")
-    } else {
-        AndroidView(
-            factory = { context ->
-                PieChart(context).apply {
-                    val entries = displaySpending.map { (cat, amt) -> PieEntry(amt.toFloat(), cat) }
-                    val dataSet = PieDataSet(entries, "").apply {
-                        colors = colorPalette
-                        valueTextSize = 16f
-                        sliceSpace = 4f
-                    }
-                    this.data = PieData(dataSet)
-                    description.isEnabled = false
-                    legend.apply {
-                        isEnabled = true
-                        textSize = 14f
-                        verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-                        horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
-                        orientation = Legend.LegendOrientation.HORIZONTAL
-                        xEntrySpace = 20f
-                    }
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(250.dp)
-        )
-        Spacer(modifier = Modifier.height(24.dp))
-        AndroidView(
-            factory = { context ->
-                BarChart(context).apply {
-                    val entries = displaySpending.mapIndexed { idx, entry ->
-                        BarEntry(idx.toFloat(), entry.second.toFloat())
-                    }
-                    val dataSet = BarDataSet(entries, "Categories").apply {
-                        colors = colorPalette
-                        valueTextSize = 16f
-                    }
-                    val data = BarData(dataSet)
-                    this.data = data
-                    description.isEnabled = false
-                    xAxis.apply {
-                        valueFormatter = IndexAxisValueFormatter(displaySpending.map { it.first })
-                        position = XAxis.XAxisPosition.BOTTOM
-                        setDrawGridLines(false)
-                        granularity = 1f
-                        textSize = 12f
-                        labelRotationAngle = -45f
-                    }
-                    axisRight.isEnabled = false
-                    legend.isEnabled = false
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(250.dp)
-        )
-    }
 }

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/SpendingScreen.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/budget/SpendingScreen.kt
@@ -18,6 +18,8 @@ import com.example.aibudgetapp.ui.screens.transaction.AddTransactionViewModel
 import java.time.LocalDate
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import com.example.aibudgetapp.ui.screens.transaction.Period
+
 
 
 @Composable
@@ -31,11 +33,19 @@ fun SpendingScreen(
     val periods = listOf("Monthly", "Weekly")
     var selectedPeriod by remember { mutableStateOf(periods[0]) }
 
-    // Simple Segmented Toggle UI
+
+
+
     Row(Modifier.padding(top = 16.dp, bottom = 8.dp)) {
         periods.forEach { period ->
             Button(
-                onClick = { selectedPeriod = period },
+                onClick = {
+                    selectedPeriod = period
+                    addTransactionViewModel.setPeriod(
+                        if (period == "Weekly") Period.WEEK else Period.MONTH
+                    )
+                   // addTransactionViewModel.fetchTransactions() // Fetch transactions after period change
+                },
                 colors = ButtonDefaults.buttonColors(
                     containerColor = if (selectedPeriod == period) MaterialTheme.colorScheme.primary
                     else MaterialTheme.colorScheme.surface
@@ -44,6 +54,7 @@ fun SpendingScreen(
             ) { Text(period) }
         }
     }
+
 
 
     val today = java.time.LocalDate.now()

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
@@ -63,11 +63,14 @@ class AddTransactionViewModel(
     private val _spendingByCategory = MutableStateFlow<Map<String, Double>>(emptyMap())
     val spendingByCategory: StateFlow<Map<String, Double>> = _spendingByCategory
 
+    init {
+        fetchTransactions()   // automatically load when ViewModel is created
+    }
+
     // Call this whenever transaction list changes
     fun updateSpendingByCategory() {
         _spendingByCategory.value = getSpendingByCategory()
     }
-    // --- END NEW CODE ---
 
     fun getSpendingByCategoryFlow(): Flow<Map<String, Double>> {
         return flowOf(

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
@@ -263,6 +263,23 @@ class AddTransactionViewModel(
             imageUri = imageUri
         )
     }
+    fun importTransactions(transactions: List<Transaction>) {
+        transactions.forEach { tx ->
+            repository.addTransaction(
+                transaction = tx,
+                onSuccess = {
+                    Log.d("CSV_IMPORT", "Inserted txn: $tx")
+                    fetchTransactions()           // refresh UI after insert
+                    updateSpendingByCategory()    // keep charts in sync
+                },
+                onFailure = { e ->
+                    Log.e("CSV_IMPORT", "Failed insert: ${e.message}")
+                    transactionError = true
+                }
+            )
+        }
+    }
+
 
     fun deleteTransaction(id: String) {
         repository.deleteTransaction(

--- a/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
+++ b/app/src/main/java/com/example/aibudgetapp/ui/screens/transaction/AddTransactionViewModel.kt
@@ -273,7 +273,7 @@ class AddTransactionViewModel(
     }
 }
 
-// Factory stays the same
+
 class AddTransactionViewModelFactory(
     private val repository: TransactionRepository
 ) : ViewModelProvider.Factory {


### PR DESCRIPTION
 Summary
This PR implements budget end date logic and enables CSV import for bank statements.

Changes
- **Budgets & Pie Charts**
  - Added support for weekly and monthly budgets (starting from 2025-08-01 to today).
  - Only one active weekly and one active monthly budget are allowed for now.
  - Pie charts now reflect spending against the active budget.
  - Users must delete the existing budget before creating a new one (dates must align).
  - Spending screen loads charts automatically; switching weekly/monthly requires refreshing transactions.

- CSV Import
  - Added `importTransactions()` in `AddTransactionViewModel` to batch-insert parsed CSV transactions.
  - Updated `UploadPhotoButton` to persist imported transactions into Firestore.
  - Verified data is saved under `users/{uid}/transactions`.

- Bar Chart
  - Displays day-to-day transaction spending.
  - Will be expanded in Sprint 2 to align with budgets.